### PR TITLE
SMTP framework and verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ It shall look like that:
 	"smtprelaymailpassword": "<Password for sender>",
 	"ServiceDeskRateLimitInterval": <Interval (in seconds) where access is tracked>,
 	"ServiceDeskRateLimitReports": <Maximun ammount of access per user in interval> 
+	"restrict_email_domains": <array of domains>
+	"require_email_verification": <bool>
+	"email_verification_token_lifetime": <duration string (in "ns", "us" (or "µs"), "ms", "s", "m", "h")>
 }
 ```
 

--- a/api.yml
+++ b/api.yml
@@ -244,7 +244,7 @@ paths:
         429:
           description: Too many requests
   /user/verify:
-    post:
+    get:
       tags:
         - user
         - verification

--- a/api.yml
+++ b/api.yml
@@ -239,6 +239,8 @@ paths:
           description: Successfully sent verification mail
         401:
           description: Not logged in
+        409:
+          description: Already verified
         429:
           description: Too many requests
   /user/verify:

--- a/api.yml
+++ b/api.yml
@@ -248,7 +248,7 @@ paths:
       tags:
         - user
         - verification
-      summary: Requests an EMail verifcation
+      summary: Verifies a token-url recieved by mail
       operationId: UserVerify
       parameters:
         - name: token

--- a/api.yml
+++ b/api.yml
@@ -225,6 +225,39 @@ paths:
           description: User is now Logged out
         400:
           description: Not logged in
+  /user/request_verify:
+    get:
+      tags:
+        - user
+        - verification
+      summary: Requests an EMail verifcation
+      security:
+        - User: []
+      operationId: UserRequestVerify
+      responses:
+        200:
+          description: Successfully sent verification mail
+        401:
+          description: Not logged in
+        429:
+          description: Too many requests
+  /user/verify:
+    post:
+      tags:
+        - user
+        - verification
+      summary: Requests an EMail verifcation
+      operationId: UserVerify
+      parameters:
+        - name: token
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successfully verified user
+        404:
+          description: Invalid token
 components:
   securitySchemes:
     User:

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20190707035753-2be1aa521ff4/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
@@ -97,6 +98,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
@@ -126,6 +128,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -197,6 +200,7 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/bugreport.go
+++ b/internal/bugreport.go
@@ -2,10 +2,8 @@ package wtfd
 
 import (
 	"errors"
-	"fmt"
 	"time"
-	"strconv"
-	"net/smtp"
+	"github.com/wtfd-tech/wtfd/internal/smtp"
 )
 
 
@@ -81,15 +79,7 @@ func BRDispatchBugreport(u *User, subject string, content string) error {
 		return errors.New("Service Desk is disabled")
 	}
 
-	recipient := BRServiceDeskAddress
-	recipients := []string{recipient}
-	formatContent := fmt.Sprintf("To: %s\r\nFrom: %s\r\nSubject: %s\r\nReply-To: %s\r\n\r\n%s\r\n",
-		recipient, BRSMTPUser+"@"+BRSMTPHost,  subject, u.Name, content)
-
-	auth := smtp.PlainAuth("", BRSMTPUser+"@"+BRSMTPHost, BRSMTPPassword, BRSMTPHost)
-
-	err := smtp.SendMail(BRSMTPHost+":"+strconv.Itoa(BRSMTPPort),
-		auth, BRSMTPUser+"@"+BRSMTPHost, recipients, []byte(formatContent))
+	err := smtp.DispatchMail(BRServiceDeskAddress, u.Name, subject, content, nil)
 	if err == nil {
 		registerUserAccess(u)
 	}

--- a/internal/bugreport.go
+++ b/internal/bugreport.go
@@ -78,6 +78,9 @@ func BRDispatchBugreport(u *User, subject string, content string) error {
 	if !BRServiceDeskEnabled {
 		return errors.New("Service Desk is disabled")
 	}
+	if !smtp.Config.Enabled {
+		return errors.New("SMTP is disabled")
+	}
 
 	err := smtp.DispatchMail(BRServiceDeskAddress, u.Name, subject, content, nil)
 	if err == nil {

--- a/internal/bugreport.go
+++ b/internal/bugreport.go
@@ -82,7 +82,10 @@ func BRDispatchBugreport(u *User, subject string, content string) error {
 		return errors.New("SMTP is disabled")
 	}
 
-	err := smtp.DispatchMail(BRServiceDeskAddress, u.Name, subject, content, nil)
+	fields := make(map[string]string)
+	fields["ReplyTo"] = u.Name
+
+	err := smtp.DispatchMail(BRServiceDeskAddress, subject, content, fields)
 	if err == nil {
 		registerUserAccess(u)
 	}

--- a/internal/orm.go
+++ b/internal/orm.go
@@ -400,13 +400,14 @@ func ormLoadUser(name string) (User, error) {
 // his own user object while verifying the token. Current architecture does
 // not allow to solve this without expense
 func ormUserByToken(token string) (User, error) {
-	var user User
+	var user _ORMUser
 
 	if _, err := engine.Where("VerifyToken = ?", token).Get(&user); err != nil {
 		return User{}, err
 	}
 
-	return user, nil
+	// Load all data into real User struct
+	return ormLoadUser(user.Name)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/internal/orm.go
+++ b/internal/orm.go
@@ -30,7 +30,7 @@ type _ORMUser struct {
 	Admin       bool
 	Hash        []byte
 	Points      int
-	Verified    bool
+	Verified    int
 	VerifyToken string    `xorm:"varchar(32)"`
 	VerifyDeadline time.Time
 }
@@ -209,13 +209,18 @@ func ormUpdateUser(user User) error {
 		return errUserNotExisting
 	}
 
+	verified := 0
+	if user.VerifiedInfo.IsVerified {
+		verified = 1
+	}
+
 	u = _ORMUser{
 		Name:           user.Name,
 		Hash:           user.Hash,
 		DisplayName:    user.DisplayName,
 		Points:         user.Points,
 		Admin:          user.Admin,
-		Verified:       user.VerifiedInfo.IsVerified,
+		Verified:       verified,
 		VerifyToken:    user.VerifiedInfo.VerifyToken,
 		VerifyDeadline: user.VerifiedInfo.VerifyDeadline,
 	}
@@ -375,6 +380,11 @@ func ormLoadUser(name string) (User, error) {
 		return User{}, err
 	}
 
+	verified := false
+	if user.Verified == 1 {
+		verified = true
+	}
+
 	u = User{
 		Name:        user.Name,
 		Hash:        user.Hash,
@@ -382,7 +392,7 @@ func ormLoadUser(name string) (User, error) {
 		Admin:       user.Admin,
 		Points:      user.Points,
 		VerifiedInfo: VerifyInfo {
-			IsVerified: user.Verified,
+			IsVerified: verified,
 			VerifyToken: user.VerifyToken,
 			VerifyDeadline: user.VerifyDeadline,
 		},

--- a/internal/orm.go
+++ b/internal/orm.go
@@ -83,7 +83,7 @@ func NewUser(name, password, displayname string) (User, error) {
 		fmt.Printf("New User %s is an Admin\n", name)
 
 	}
-	return User{Name: name, Hash: hash, DisplayName: displayname, Admin: isAdmin}, nil
+	return User{Name: name, Hash: hash, DisplayName: displayname, Admin: isAdmin, Verified: false}, nil
 
 }
 

--- a/internal/orm.go
+++ b/internal/orm.go
@@ -395,4 +395,18 @@ func ormLoadUser(name string) (User, error) {
 	return u, nil
 }
 
+// get a username by a verify token.
+// NOTE: race condition possible, when user changes properties of
+// his own user object while verifying the token. Current architecture does
+// not allow to solve this without expense
+func ormUserByToken(token string) (User, error) {
+	var user User
+
+	if _, err := engine.Where("VerifyToken = ?", token).Get(&user); err != nil {
+		return User{}, err
+	}
+
+	return user, nil
+}
+
 ////////////////////////////////////////////////////////////////////////////////

--- a/internal/orm.go
+++ b/internal/orm.go
@@ -30,6 +30,9 @@ type _ORMUser struct {
 	Admin       bool
 	Hash        []byte
 	Points      int
+	Verified    bool
+	VerifyToken string    `xorm:"varchar(32)"`
+	VerifyDeadline time.Time
 }
 
 type _ORMChallengesByUser struct {
@@ -83,7 +86,7 @@ func NewUser(name, password, displayname string) (User, error) {
 		fmt.Printf("New User %s is an Admin\n", name)
 
 	}
-	return User{Name: name, Hash: hash, DisplayName: displayname, Admin: isAdmin, Verified: false}, nil
+	return User{Name: name, Hash: hash, DisplayName: displayname, Admin: isAdmin, VerifiedInfo: VerifyInfo{IsVerified: false}}, nil
 
 }
 
@@ -207,11 +210,14 @@ func ormUpdateUser(user User) error {
 	}
 
 	u = _ORMUser{
-		Name:        user.Name,
-		Hash:        user.Hash,
-		DisplayName: user.DisplayName,
-		Points:      user.Points,
-		Admin:       user.Admin,
+		Name:           user.Name,
+		Hash:           user.Hash,
+		DisplayName:    user.DisplayName,
+		Points:         user.Points,
+		Admin:          user.Admin,
+		Verified:       user.VerifiedInfo.IsVerified,
+		VerifyToken:    user.VerifiedInfo.VerifyToken,
+		VerifyDeadline: user.VerifiedInfo.VerifyDeadline,
 	}
 	// fmt.Printf("a: %#v", u)
 
@@ -375,6 +381,11 @@ func ormLoadUser(name string) (User, error) {
 		DisplayName: user.DisplayName,
 		Admin:       user.Admin,
 		Points:      user.Points,
+		VerifiedInfo: VerifyInfo {
+			IsVerified: user.Verified,
+			VerifyToken: user.VerifyToken,
+			VerifyDeadline: user.VerifyDeadline,
+		},
 	}
 
 	if u.Completed, err = ormChallengesSolved(u); err != nil {

--- a/internal/server.go
+++ b/internal/server.go
@@ -558,7 +558,7 @@ func requestVerify(w http.ResponseWriter, r *http.Request) {
 	//TODO
 
 	token := generateRandomString(32)
-	content := fmt.Sprintf("Click here to verify your WTFd account:"+
+	content := fmt.Sprintf("Click here to verify your WTFd account: "+
 		"http://%s/verify?token=%s\r\n\r\n"+
 		"If you don't know about this, you can ignore this Mail", r.Host, token)
 

--- a/internal/server.go
+++ b/internal/server.go
@@ -666,6 +666,7 @@ func Server() error {
 			smtp.Config.User = split[0]
 			smtp.Config.Host = split[1]
 
+			smtp.Config.Enabled = true
 			BRServiceDeskEnabled = true
 		}
 		BRRateLimitReports = config.ServiceDeskRateLimitReports

--- a/internal/server.go
+++ b/internal/server.go
@@ -617,8 +617,7 @@ func verify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user.VerifiedInfo.IsVerified = true
-	user.VerifiedInfo.VerifyDeadline = time.Time{}
-	user.VerifiedInfo.VerifyToken = ""
+	user.VerifiedInfo.VerifyDeadline = time.Date(0, 0, 0, 0, 0, 0, 0, time.Local) // invalidate
 
 	/* write user back to db */
 	if err = ormUpdateUser(user); err != nil {

--- a/internal/server.go
+++ b/internal/server.go
@@ -603,6 +603,8 @@ func favicon(w http.ResponseWriter, r *http.Request) {
 // Server is the main server func, start it with
 //  log.Fatal(wtfd.Server())
 func Server() error {
+	utilInit()
+
 	gob.Register(&User{})
 
 	var key []byte

--- a/internal/server.go
+++ b/internal/server.go
@@ -566,7 +566,7 @@ func requestVerify(w http.ResponseWriter, r *http.Request) {
 	err = smtp.DispatchMail(user.Name, "WTFd Verification", content, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Printf("SMTP error: %s", err.Error())
+		log.Printf("SMTP error: %s\n", err.Error())
 		return
 	}
 
@@ -575,7 +575,7 @@ func requestVerify(w http.ResponseWriter, r *http.Request) {
 	user.VerifiedInfo.VerifyDeadline = time.Now().Add(config.EmailVerificationTokenLifetime)
 	if err = ormUpdateUser(user); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Printf("ORM error: %s", err.Error())
+		log.Printf("ORM error: %s\n", err.Error())
 		return
 	}
 

--- a/internal/server.go
+++ b/internal/server.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/wtfd-tech/wtfd/internal/smtp"
+
 	"github.com/gobuffalo/packr/v2"
 	"github.com/gomarkdown/markdown"
 	"github.com/gorilla/mux"
@@ -646,7 +648,7 @@ func Server() error {
 			BRServiceDeskEnabled = false
 		} else {
 			BRServiceDeskAddress = config.ServiceDeskAddress
-			BRSMTPPassword = config.SMTPRelayPasswd
+			smtp.Config.Password = config.SMTPRelayPasswd
 
 			// Parse relay mail string
 			split := strings.Split(config.SMTPRelayString, ":")
@@ -654,15 +656,15 @@ func Server() error {
 			if len(split) < 2 {
 				return errors.New("Invalid smtprelaymailwithport format!")
 			}
-			if BRSMTPPort, err = strconv.Atoi(split[1]); err != nil {
+			if smtp.Config.Port, err = strconv.Atoi(split[1]); err != nil {
 				return err
 			}
 			split = strings.Split(split[0], "@")
 			if len(split) < 2 {
 				return errors.New("Invalid smtprelaymailwithport format!")
 			}
-			BRSMTPUser = split[0]
-			BRSMTPHost = split[1]
+			smtp.Config.User = split[0]
+			smtp.Config.Host = split[1]
 
 			BRServiceDeskEnabled = true
 		}
@@ -670,7 +672,7 @@ func Server() error {
 		BRRateLimitInterval = config.ServiceDeskRateLimitInterval
 		if BRServiceDeskEnabled {
 			fmt.Printf("ServiceDesk running at %s (Send via %s@%s:%d)  (Max %dR/%.02fs)\n",
-				BRServiceDeskAddress, BRSMTPUser, BRSMTPHost, BRSMTPPort,
+				BRServiceDeskAddress, smtp.Config.User, smtp.Config.Host, smtp.Config.Port,
 			    BRRateLimitReports, BRRateLimitInterval)
 		} else {
 			fmt.Println("ServiceDesk disabled")

--- a/internal/server.go
+++ b/internal/server.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/wtfd-tech/wtfd/internal/smtp"
 
@@ -628,6 +629,7 @@ func Server() error {
 			Icon:                         "icon.svg",
 			FirstLine:                    "WTFd",
 			SecondLine:                   `CTF`,
+			EmailVerificationTokenLifetimeString: "168h", // One week
 		}
 		configBytes, _ := json.MarshalIndent(config, "", "\t")
 		_ = ioutil.WriteFile("config.json", configBytes, os.FileMode(0600))
@@ -685,6 +687,13 @@ func Server() error {
 			    BRRateLimitReports, BRRateLimitInterval)
 		} else {
 			fmt.Println("ServiceDesk disabled")
+		}
+
+		// Email verification
+		config.EmailVerificationTokenLifetime, err = time.ParseDuration(config.EmailVerificationTokenLifetimeString)
+		if err != nil {
+			log.Printf("Could not parse email_verification_lifetime: %s", err.Error())
+			return err
 		}
 	}
 

--- a/internal/server.go
+++ b/internal/server.go
@@ -529,6 +529,14 @@ func reportBug(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "OK")
 }
 
+func requestVerify(w http.ResponseWriter, r *http.Request) {
+
+}
+
+func verify(w http.ResponseWriter, r *http.Request) {
+
+}
+
 func solutionview(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	chall, err := challs.Find(vars["chall"])
@@ -820,6 +828,9 @@ func Server() error {
 	r.HandleFunc("/changepassword", changePassword)
 	r.HandleFunc("/submitflag", submitFlag)
 	r.HandleFunc("/ws", leaderboardWS)
+	r.HandleFunc("/reportbug", reportBug)
+	r.HandleFunc("/request_verify", requestVerify)
+	r.HandleFunc("/verify", verify)
 	r.HandleFunc("/reportbug", reportBug)
 	r.HandleFunc("/{chall}", mainpage)
 	r.HandleFunc("/detailview/{chall}", detailview)

--- a/internal/smtp/smtp.go
+++ b/internal/smtp/smtp.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"strconv"
 	"net/smtp"
+	"errors"
 )
 
 /**
  * Dispatch a mail via send config
  */
 func DispatchMail(recipient string, subject string, content string, fields map[string]string) error {
+	if !Config.Enabled {
+		return errors.New("SMTP is disabled")
+	}
 
 	auth := smtp.PlainAuth("", Config.User+"@"+Config.Host, Config.Password, Config.Host)
 

--- a/internal/smtp/smtp.go
+++ b/internal/smtp/smtp.go
@@ -1,0 +1,24 @@
+package smtp
+
+import (
+	"fmt"
+	"strconv"
+	"net/smtp"
+)
+
+/**
+ * Dispatch a mail via send config
+ */
+func DispatchMail(recipient string, replyTo string, subject string, content string, fields map[string]string) error {
+	auth := smtp.PlainAuth("", Config.User+"@"+Config.Host, Config.Password, Config.Host)
+
+	recipients := []string{recipient}
+
+	formatContent := fmt.Sprintf("To: %s\r\nFrom: %s\r\nSubject: %s\r\nReply-To: %s\r\n\r\n%s\r\n",
+		recipient, Config.User+"@"+Config.Host,  subject, replyTo, content)
+
+	err := smtp.SendMail(Config.Host+":"+strconv.Itoa(Config.Port), auth,
+		Config.User+"@"+Config.Host, recipients, []byte(formatContent))
+
+	return err
+}

--- a/internal/smtp/smtp.go
+++ b/internal/smtp/smtp.go
@@ -9,13 +9,19 @@ import (
 /**
  * Dispatch a mail via send config
  */
-func DispatchMail(recipient string, replyTo string, subject string, content string, fields map[string]string) error {
+func DispatchMail(recipient string, subject string, content string, fields map[string]string) error {
+
 	auth := smtp.PlainAuth("", Config.User+"@"+Config.Host, Config.Password, Config.Host)
 
 	recipients := []string{recipient}
 
-	formatContent := fmt.Sprintf("To: %s\r\nFrom: %s\r\nSubject: %s\r\nReply-To: %s\r\n\r\n%s\r\n",
-		recipient, Config.User+"@"+Config.Host,  subject, replyTo, content)
+	extraFields := ""
+	for field, value := range(fields) {
+		extraFields += fmt.Sprintf("%s: %s\r\n", field, value)
+	}
+
+	formatContent := fmt.Sprintf("To: %s\r\nFrom: %s\r\nSubject: %s\r\n%s\r\n%s\r\n",
+		recipient, Config.User+"@"+Config.Host,  subject, extraFields, content)
 
 	err := smtp.SendMail(Config.Host+":"+strconv.Itoa(Config.Port), auth,
 		Config.User+"@"+Config.Host, recipients, []byte(formatContent))

--- a/internal/smtp/structs.go
+++ b/internal/smtp/structs.go
@@ -1,0 +1,11 @@
+package smtp
+
+type SMTPConfig struct {
+	Port     int     // server to server smtp port
+	User     string  // user used for sending mails
+	Password string  // password for user
+	Host     string  // host where the send stmp server runns at
+	Enabled  bool    // Is smtp service enabled
+}
+
+var Config SMTPConfig

--- a/internal/structs.go
+++ b/internal/structs.go
@@ -57,8 +57,10 @@ type Config struct {
 	SMTPRelayPasswd     string `json:"smtprelaymailpassword"`
 	ServiceDeskRateLimitInterval float64 `servicedeskratelimitinterval` // See bugreport.go
 	ServiceDeskRateLimitReports  int `servicedeskratelimitreports`  // See bugreport.go
-	RestrictEmailDomains         []string      `json:"restrict_email_domains"`
-	RequireEmailVerification     bool          `json:"require_email_verification"`
+	RestrictEmailDomains         []string       `json:"restrict_email_domains"`
+	RequireEmailVerification     bool           `json:"require_email_verification"`
+	EmailVerificationTokenLifetimeString string `json:"email_verification_token_lifetime"`
+	EmailVerificationTokenLifetime       time.Duration `json:"-"`
 }
 
 type VerifyInfo struct {

--- a/internal/structs.go
+++ b/internal/structs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"sort"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -60,15 +61,21 @@ type Config struct {
 	RequireEmailVerification     bool          `json:"require_email_verification"`
 }
 
+type VerifyInfo struct {
+	IsVerified bool
+	VerifyToken string
+	VerifyDeadline time.Time
+}
+
 // User, was ist das wohl
 type User struct {
-	Name        string `json:"name"`
-	Hash        []byte
-	DisplayName string `json:"displayname"`
-	Completed   []*Challenge
-	Admin       bool `json:"admin"`
-	Points      int  `json:"points"`
-	Verified    bool
+	Name         string `json:"name"`
+	Hash         []byte
+	DisplayName  string `json:"displayname"`
+	Completed    []*Challenge
+	Admin        bool `json:"admin"`
+	Points       int  `json:"points"`
+	VerifiedInfo VerifyInfo
 }
 
 type gridinfo struct {

--- a/internal/structs.go
+++ b/internal/structs.go
@@ -68,6 +68,7 @@ type User struct {
 	Completed   []*Challenge
 	Admin       bool `json:"admin"`
 	Points      int  `json:"points"`
+	Verified    bool
 }
 
 type gridinfo struct {

--- a/internal/util.go
+++ b/internal/util.go
@@ -4,7 +4,17 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"time"
 )
+
+const (
+	letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-" //64 chars
+)
+
+// Initialize utilities
+func utilInit() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 // https://stackoverflow.com/a/35099450
 func stringCompareLess(si, sj string) bool {
@@ -14,6 +24,14 @@ func stringCompareLess(si, sj string) bool {
 		return si < sj
 	}
 	return siLower < sjLower
+}
+
+func generateRandomString(n int) string {
+	b := make([]byte, n)
+	for i := 0; i < n; i++ {
+		b[i] = letterBytes[int(rand.Int() & 0b00111111)]
+	}
+	return string(b)
 }
 
 func generateUserName() (string, error) {


### PR DESCRIPTION
Changes:
- added generic SMTP package (for sending with a config defined mail account)
- email verification api (described in api.yml)

Solves backend for https://github.com/wtfd-tech/wtfd/issues/16

Ratelimiting is not implemented yet, because we don't have a general ratelimiting framework (which would be appropriat)

Someone might review my changes in api.yml